### PR TITLE
Stop cache in the RUN context it is running in

### DIFF
--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -34,9 +34,12 @@ WORKDIR ${TMP_INSTALL_DIR}
 ADD cache-2015.1.0.429.0-lnxrhx64.tar.gz .
 
 # update OS + dependencies & run Caché silent install___________________________________
-RUN yum -y update && yum -y install tar hostname net-tools && ln -sf /etc/localtime /usr/share/zoneinfo/Europe/Rome &&./cinstall_silent
+RUN yum -y update && \
+    yum -y install tar hostname net-tools && \
+    ln -sf /etc/localtime /usr/share/zoneinfo/Europe/Rome && \
+    ./cinstall_silent && \
+    ccontrol stop $ISC_PACKAGE_INSTANCENAME quietly 
 COPY cache.key $ISC_PACKAGE_INSTALLDIR/mgr/
-RUN ccontrol stop $ISC_PACKAGE_INSTANCENAME quietly 
 
 # TCP sockets that can be accessed if user wants to (see 'docker run -p' flag)
 EXPOSE 57772 1972 22


### PR DESCRIPTION
Each time we do a RUN command docker starts a new container to build from, so in the context of the RUN command after the cache.key is copied, Cache isn't actually running to be able to stop it (but doesn't output anything to stdout either way).

This moves the `ccontrol stop` command to the context where cache is actually running (it's started automatically by the installer) and shuts it down cleanly.