### PR TITLE
2016.2 support and other nice things

### DIFF
--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR ${TMP_INSTALL_DIR}
 
 # update OS + dependencies & run Caché silent install___________________________________
 RUN yum -y update && \
-    yum -y install tar hostname net-tools which wget && \
+    yum -y install tar hostname net-tools which wget java && \
     wget -qO /dev/null --keep-session-cookies --save-cookies /dev/stdout --post-data="UserName=$WRC_USERNAME&Password=$WRC_PASSWORD" 'https://login.intersystems.com/login/SSO.UI.Login.cls?referrer=https%253A//wrc.intersystems.com/wrc/login.csp' \
       | wget -O - --load-cookies /dev/stdin 'https://wrc.intersystems.com/wrc/WRC.StreamServer.cls?FILE=/wrc/distrib/cache-2016.2.0.736.0-lnxrhx64.tar.gz' \
         | tar xvfzC - . && \

--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -19,27 +19,35 @@ MAINTAINER user <user@company.com>
 #
 ENV TMP_INSTALL_DIR=/tmp/distrib
 
+# vars to get the Cache kit from WRC Distribution
+ENV WRC_USERNAME="user@company.com"
+ENV WRC_PASSWORD="your_password_here"
+
 # vars for Caché silent install
 ENV ISC_PACKAGE_INSTANCENAME="CACHE"
 ENV ISC_PACKAGE_INSTALLDIR="/usr/cachesys"
 ENV ISC_PACKAGE_UNICODE="Y"
 
 # Caché distribution file________________________________________________________________
-# set-up and install Caché from distrib_tmp dir 
-# -container bloating here; no volumes dismount yet! (https://github.com/docker/docker/issues/14080 and similar)
+# set-up and install Caché from distrib_tmp dir
 RUN mkdir ${TMP_INSTALL_DIR}
 WORKDIR ${TMP_INSTALL_DIR}
 
-# fetch distrib file
-ADD cache-2016.2.0.736.0-lnxrhx64.tar.gz .
-
 # update OS + dependencies & run Caché silent install___________________________________
 RUN yum -y update && \
-    yum -y install tar hostname net-tools which && \
+    yum -y install tar hostname net-tools which wget && \
     ln -sf /etc/localtime /usr/share/zoneinfo/Europe/Rome && \
+    wget -qO /dev/null --keep-session-cookies --save-cookies /dev/stdout --post-data="UserName=$WRC_USERNAME&Password=$WRC_PASSWORD" 'https://login.intersystems.com/login/SSO.UI.Login.cls?referrer=https%253A//wrc.intersystems.com/wrc/login.csp' \
+      | wget -O - --load-cookies /dev/stdin 'https://wrc.intersystems.com/wrc/WRC.StreamServer.cls?FILE=/wrc/distrib/cache-2016.2.0.736.0-lnxrhx64.tar.gz' \
+        | tar xvfzC - . && \
     ./cache-*/cinstall_silent && \
+    rm -rf ${TMP_INSTALL_DIR}/* && \
     ccontrol stop $ISC_PACKAGE_INSTANCENAME quietly 
 COPY cache.key $ISC_PACKAGE_INSTALLDIR/mgr/
+
+# Clear sensitive credentials so they don't leak into the image itself
+ENV WRC_USERNAME=""
+ENV WRC_PASSWORD=""
 
 # TCP sockets that can be accessed if user wants to (see 'docker run -p' flag)
 EXPOSE 57772 1972 22

--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -48,6 +48,13 @@ COPY cache.key $ISC_PACKAGE_INSTALLDIR/mgr/
 ENV WRC_USERNAME=""
 ENV WRC_PASSWORD=""
 
+# Workaround for an overlayfs bug which prevents Cache from starting with <PROTECT> errors
+COPY ccontrol-wrapper.sh /usr/bin/
+RUN cd /usr/bin                     && \
+    rm ccontrol                     && \
+    mv ccontrol-wrapper.sh ccontrol && \
+    chmod 555 ccontrol
+
 # TCP sockets that can be accessed if user wants to (see 'docker run -p' flag)
 EXPOSE 57772 1972 22
 

--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -1,10 +1,10 @@
 # This Docker manifest file builds a container with:
 # - sshd running (linux containers don't usually have it)
-# - Caché 2015.1 and 
+# - Caché 2016.2 and 
 # - it handles container PID 1 via ccontainermain which offers various flags
 #
 # build the new image with:
-# $ docker build --force-rm --no-cache -t centos7:C151 .
+# $ docker build --force-rm --no-cache -t cache:2016.2 .
 #--
 
 # pull from this repository
@@ -20,7 +20,7 @@ MAINTAINER user <user@company.com>
 ENV TMP_INSTALL_DIR=/tmp/distrib
 
 # vars for Caché silent install
-ENV ISC_PACKAGE_INSTANCENAME="C151"
+ENV ISC_PACKAGE_INSTANCENAME="CACHE"
 ENV ISC_PACKAGE_INSTALLDIR="/usr/cachesys"
 ENV ISC_PACKAGE_UNICODE="Y"
 
@@ -31,13 +31,13 @@ RUN mkdir ${TMP_INSTALL_DIR}
 WORKDIR ${TMP_INSTALL_DIR}
 
 # fetch distrib file
-ADD cache-2015.1.0.429.0-lnxrhx64.tar.gz .
+ADD cache-2016.2.0.736.0-lnxrhx64.tar.gz .
 
 # update OS + dependencies & run Caché silent install___________________________________
 RUN yum -y update && \
-    yum -y install tar hostname net-tools && \
+    yum -y install tar hostname net-tools which && \
     ln -sf /etc/localtime /usr/share/zoneinfo/Europe/Rome && \
-    ./cinstall_silent && \
+    ./cache-*/cinstall_silent && \
     ccontrol stop $ISC_PACKAGE_INSTANCENAME quietly 
 COPY cache.key $ISC_PACKAGE_INSTALLDIR/mgr/
 
@@ -51,7 +51,7 @@ ADD ccontainermain .
 ENTRYPOINT  ["/ccontainermain"]
 
 # run via:
-# docker run -d -p 57772:57772 -p 2222:22 -e ROOT_PASS="linux" <docker_image_id> -i=C151 -xstart=/run.sh 
+# docker run -d -p 57772:57772 -p 2222:22 -e ROOT_PASS="linux" <docker_image_id> -i=CACHE -xstart=/run.sh 
 #
 # more options & explinations
 # $ docker run -d			// detached in the background; accessed only via network
@@ -63,7 +63,7 @@ ENTRYPOINT  ["/ccontainermain"]
 # <docker_image_id> 		// see docker images to fetch the right name & tag or id
 # 							// after the Docker image id, we can specify all the flags supported by 'ccontainermain'
 #							// see this page for more info https://github.com/zrml/ccontainermain
-# -i=C151					// this is the Cachè instance name
+# -i=CACHE					// this is the Cachè instance name
 # -xstart=/run.sh			// eXecute another service at startup time
 #							// run.sh starts sshd (part of tutum centos container)
 #							// for more info see https://docs.docker.com/reference/run/

--- a/dockerfile/Caché+SSH/Dockerfile
+++ b/dockerfile/Caché+SSH/Dockerfile
@@ -36,7 +36,6 @@ WORKDIR ${TMP_INSTALL_DIR}
 # update OS + dependencies & run Caché silent install___________________________________
 RUN yum -y update && \
     yum -y install tar hostname net-tools which wget && \
-    ln -sf /etc/localtime /usr/share/zoneinfo/Europe/Rome && \
     wget -qO /dev/null --keep-session-cookies --save-cookies /dev/stdout --post-data="UserName=$WRC_USERNAME&Password=$WRC_PASSWORD" 'https://login.intersystems.com/login/SSO.UI.Login.cls?referrer=https%253A//wrc.intersystems.com/wrc/login.csp' \
       | wget -O - --load-cookies /dev/stdin 'https://wrc.intersystems.com/wrc/WRC.StreamServer.cls?FILE=/wrc/distrib/cache-2016.2.0.736.0-lnxrhx64.tar.gz' \
         | tar xvfzC - . && \

--- a/dockerfile/Caché+SSH/ccontrol-wrapper.sh
+++ b/dockerfile/Caché+SSH/ccontrol-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Work around a werid overlayfs bug where files don't open properly if they haven't been
+# touched first - see the yum-ovl plugin for a similar workaround
+if [ "${1,,}" == "start" ]; then
+    find / -name CACHE.DAT -exec touch {} \;
+fi
+
+/usr/local/etc/cachesys/ccontrol $@


### PR DESCRIPTION
As promised, a more up-to-date example with a few other nice things, notably:
* 2016.2 support
* automatic kit downloading from WRC (requires a WRC username/password though)
* removed the timezone link
* support for starting Cache during docker hub builds (or builds on systems using OverlayFS)
* Java for ZEN Reports
* less bloat = smaller image size

I have a few other bits and bobs laying around - SNMP support and an old Java MaxHeapSize workaround which may still be required. I'll submit them as separate PR's once I have a chance to test whether they still work/are required.

Also of note - the tutum centos image is [officially deprecated](https://github.com/tutumcloud/tutum-centos), but the official centos image doesn't contain an ssh server. There's a bit of work involved to set that up (you need to set the root password, generate keys, etc etc) so I left it using tutum since this dockerfile is specifically an example including sshd.