### PR TITLE
Don't workaround overlay bugs on non-overlay systems

### DIFF
--- a/dockerfile/Caché+SSH/ccontrol-wrapper.sh
+++ b/dockerfile/Caché+SSH/ccontrol-wrapper.sh
@@ -2,7 +2,10 @@
 
 # Work around a werid overlayfs bug where files don't open properly if they haven't been
 # touched first - see the yum-ovl plugin for a similar workaround
-if [ "${1,,}" == "start" ]; then
+df / | grep -q overlay
+filesystemIsOverlay=$?
+
+if [ "${1,,}" == "start" ] && [ $filesystemIsOverlay -eq 0 ]; then
     find / -name CACHE.DAT -exec touch {} \;
 fi
 


### PR DESCRIPTION
I just discovered that using this in a Dockerfile build step will needlessly copy all `CACHE.DAT`s to the next layer, since the `touch` is enough to make the filesystem think the files changed

This modifies the overlayfs workaround to only happen on the filesystem that needs the workaround, so at least non-overlay filesystems won't produce oddly large docker images.