### PR TITLE
Add a hook for before Cache starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Docker gives a 10 seconds default and then bring the container down. Not ideal f
 * -n for namespace; it allows to specify the namespace where to run a program; -n=USER
 * -r for routine; it allows to specify the routine name to start; -r=myApp or -r="##class(package.class).method()"
 * -shmem for tuning SHMMAX; default val 512MB; -shmem=1024
-* -xstart for eXecuting anything before Caché is started; -xstart=/myapp/runMyExtraServive.sh
+* -xprestart for eXecuting anything before Caché is started; -xprestart=/myapp/runMyExtraServive.sh
+* -xstart for eXecuting anything after Caché is started; -xstart=/myapp/runMyExtraServive.sh
 * -xstop for eXecuting anything after the Caché shutdown; -xstop=/bringAllMyProcsDown.sh
 * -cstart it's a boolean defaulted to true; It gives us the option to start a container without starting Caché; -cstart=true
 * -cstop it's a boolean defaulted to true; it gives the option to skip the Caché shutdown; -cstop=false


### PR DESCRIPTION
The current `-xstart` flag is called after Cache has been signalled to start, which is too late to make modifications to the `cache.cpf` or initialize data.

This pull request adds a `-xprestart` flag which acts similarly, but is called before Cache is signalled to start.