### PR TITLE
update build.sh to pull go dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 # script to build linux exe from any GO supported arch.
+go get
 GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -o ./distrib/linux/ccontainermain ccontainermain.go


### PR DESCRIPTION
the build fails if you don't run 'go get' before to pull down the dependency