### PR TITLE
handle dependencies (only build if changed) and add clean-target to M…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,19 @@ BINARY=ccontainermain
 
 OS=linux
 ARCH=amd64
-LDFLAGS= 
+LDFLAGS=
 
-all: get-deps build
-build:
+.PHONY: all ccontainermain get-deps clean
+
+all: ccontainermain
+
+ccontainermain: get-deps distrib/${OS}/ccontainermain
+
+distrib/${OS}/ccontainermain: ccontainermain.go
 	env GOOS=${OS} GOARCH=${ARCH} go build ${LDFLAGS} -o distrib/${OS}/${BINARY} ccontainermain.go
 
 get-deps:
 	go get github.com/hpcloud/tail
+
+clean:
+	-rm distrib/${OS}/ccontainermain


### PR DESCRIPTION
This PR adds dependency handling to the Makefile so that the ccontainermain is only build if the source file is changed.

It also adds a clean target to remove the built ccontainermain.